### PR TITLE
Force 2 decimal places in number formatting

### DIFF
--- a/DatabaseMigration/Program.cs
+++ b/DatabaseMigration/Program.cs
@@ -98,7 +98,7 @@ namespace DatabaseMigration
                         }
 
                         // Update console
-                        Console.WriteLine("Caching userid {0} with payment id {1}, address {2} and balance {3:N}",
+                        Console.WriteLine("Caching userid {0} with payment id {1}, address {2} and balance {3:N2}",
                             UserId, Users[UserId].PaymentId, Users[UserId].Address, Users[UserId].Balance);
                     }
                 }
@@ -124,7 +124,7 @@ namespace DatabaseMigration
                         Transactions.Add(Tx, new Transaction(PaymentId, Amount));
 
                         // Update console
-                        Console.WriteLine("Caching tx {0} with payment id {1} and amount {2:N}",
+                        Console.WriteLine("Caching tx {0} with payment id {1} and amount {2:N2}",
                             Tx, PaymentId, Amount);
                     }
                 }
@@ -177,7 +177,7 @@ namespace DatabaseMigration
                     Command.ExecuteNonQuery();
 
                     // Update console
-                    Console.WriteLine("Adding user to new db: userid {0} with payment id {1}, address {2} and balance {3:N}",
+                    Console.WriteLine("Adding user to new db: userid {0} with payment id {1}, address {2} and balance {3:N2}",
                         User.Key, User.Value.PaymentId, User.Value.Address, User.Value.Balance);
                 }
 
@@ -195,7 +195,7 @@ namespace DatabaseMigration
                     Command.ExecuteNonQuery();
 
                     // Update console
-                    Console.WriteLine("Adding tx to new db: tx {0} with payment id {1}, amount {2:N}",
+                    Console.WriteLine("Adding tx to new db: tx {0} with payment id {1}, amount {2:N2}",
                         Transaction.Key, Transaction.Value.PaymentId, Transaction.Value.Amount);
                 }
             }

--- a/TrtlBotSharp/Bot.cs
+++ b/TrtlBotSharp/Bot.cs
@@ -17,10 +17,10 @@ namespace TrtlBotSharp
         {
             // Begin bot process in its own thread
             RunBotAsync();
+            while(true)
+            {
 
-            // Wait for keypress to exit
-            Console.ReadKey();
-
+            }
             // Close the database connection
             CloseDatabase();
         }
@@ -176,7 +176,7 @@ namespace TrtlBotSharp
                 // Check that user has enough balance for the tip
                 if (GetBalance(Reaction.UserId) < Convert.ToDecimal(Amount) * TippableUsers.Count + tipFee)
                 {
-                    await Reaction.User.Value.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N}** {1}",
+                    await Reaction.User.Value.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N2}** {1}",
                         Convert.ToDecimal(Amount) * TippableUsers.Count + tipFee, coinSymbol));
                     await Message.AddReactionAsync(new Emoji(tipLowBalanceReact));
                     return;
@@ -229,7 +229,7 @@ namespace TrtlBotSharp
                 // Check that user has enough balance for the tip
                 if (GetBalance(Reaction.UserId) < Amount + tipFee)
                 {
-                    await Reaction.User.Value.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N}** {1}",
+                    await Reaction.User.Value.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N2}** {1}",
                         Amount + tipFee, coinSymbol));
                     await Message.AddReactionAsync(new Emoji(tipLowBalanceReact));
                 }

--- a/TrtlBotSharp/Commands/Informational.cs
+++ b/TrtlBotSharp/Commands/Informational.cs
@@ -161,7 +161,7 @@ namespace TrtlBotSharp
 
             // Begin building a response
             var Response = new EmbedBuilder();
-            Response.WithTitle(string.Format("This faucet has {0:N} {1} left", (decimal)FaucetBalance["available"], TrtlBotSharp.coinSymbol));
+            Response.WithTitle(string.Format("This faucet has {0:N2} {1} left", (decimal)FaucetBalance["available"], TrtlBotSharp.coinSymbol));
             Response.WithUrl(TrtlBotSharp.faucetHost);
             Response.Description = "```Donations:\n" + TrtlBotSharp.faucetAddress + "```\n";
 

--- a/TrtlBotSharp/Commands/Market.cs
+++ b/TrtlBotSharp/Commands/Market.cs
@@ -35,7 +35,7 @@ namespace TrtlBotSharp
             Response.AddInlineField("Current", string.Format("{0} sats", Math.Round((decimal)CoinPrice["price"] * 100000000)));
             Response.AddInlineField("High", string.Format("{0} sats", Math.Round((decimal)CoinPrice["high"] * 100000000)));
             Response.AddInlineField(TrtlBotSharp.coinSymbol + "-USD", string.Format("${0:N5} USD", (decimal)CoinPrice["price"] * (decimal)BTCPrice["last"]));
-            Response.AddInlineField("Volume", string.Format("{0:N} BTC", (decimal)CoinPrice["volume"]));
+            Response.AddInlineField("Volume", string.Format("{0:N2} BTC", (decimal)CoinPrice["volume"]));
             Response.AddInlineField("BTC-USD", string.Format("{0:C} USD", (decimal)BTCPrice["last"]));
 
             // Send reply

--- a/TrtlBotSharp/Commands/Network.cs
+++ b/TrtlBotSharp/Commands/Network.cs
@@ -53,7 +53,7 @@ namespace TrtlBotSharp
             decimal Supply = TrtlBotSharp.GetSupply();
 
             // Send reply
-            await ReplyAsync(string.Format("The current circulating supply is **{0:N}** {1}", Supply, TrtlBotSharp.coinSymbol));
+            await ReplyAsync(string.Format("The current circulating supply is **{0:N2}** {1}", Supply, TrtlBotSharp.coinSymbol));
         }
     }
 }

--- a/TrtlBotSharp/Commands/Tipping.cs
+++ b/TrtlBotSharp/Commands/Tipping.cs
@@ -238,14 +238,14 @@ namespace TrtlBotSharp
             // Check that amount is over the minimum fee
             else if (Convert.ToDecimal(Amount) < TrtlBotSharp.Minimum)//TrtlBotSharp.Fee)
             {
-                await ReplyAsync(string.Format("Amount must be at least {0:N} {1}", TrtlBotSharp.Minimum/*Fee*/, TrtlBotSharp.coinSymbol));
+                await ReplyAsync(string.Format("Amount must be at least {0:N2} {1}", TrtlBotSharp.Minimum/*Fee*/, TrtlBotSharp.coinSymbol));
                 return;
             }
 
             // Check if user has enough balance
             else if (TrtlBotSharp.GetBalance(Context.Message.Author.Id) < Convert.ToDecimal(Amount) + TrtlBotSharp.tipFee)
             {
-                await Context.Message.Author.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N}** {1}",
+                await Context.Message.Author.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N2}** {1}",
                     Convert.ToDecimal(Amount) + TrtlBotSharp.tipFee, TrtlBotSharp.coinSymbol));
                 await Context.Message.AddReactionAsync(new Emoji(TrtlBotSharp.tipLowBalanceReact));
             }
@@ -277,7 +277,7 @@ namespace TrtlBotSharp
                 decimal Balance = TrtlBotSharp.GetBalance(Context.Message.Author.Id);
 
                 // Send reply
-                await Context.Message.Author.SendMessageAsync(string.Format("You have **{0:N}** {1} in your tip jar", Balance, TrtlBotSharp.coinSymbol));
+                await Context.Message.Author.SendMessageAsync(string.Format("You have **{0:N2}** {1} in your tip jar", Balance, TrtlBotSharp.coinSymbol));
             }
         }
 
@@ -294,7 +294,7 @@ namespace TrtlBotSharp
             // Check that amount is over the minimum fee
             if (Convert.ToDecimal(Amount) < TrtlBotSharp.Minimum)//TrtlBotSharp.Fee)
             {
-                await ReplyAsync(string.Format("Amount must be at least {0:N} {1}", TrtlBotSharp.Minimum/*Fee*/, TrtlBotSharp.coinSymbol));
+                await ReplyAsync(string.Format("Amount must be at least {0:N2} {1}", TrtlBotSharp.Minimum/*Fee*/, TrtlBotSharp.coinSymbol));
                 return;
             }
 
@@ -323,13 +323,13 @@ namespace TrtlBotSharp
             // Check that user has enough balance for the tip
             if (Address == "" && TrtlBotSharp.GetBalance(Context.Message.Author.Id) < Convert.ToDecimal(Amount) * TippableUsers.Count + TrtlBotSharp.tipFee)
             {
-                await Context.Message.Author.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N}** {1}",
+                await Context.Message.Author.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N2}** {1}",
                     Convert.ToDecimal(Amount) * TippableUsers.Count + TrtlBotSharp.tipFee, TrtlBotSharp.coinSymbol));
                 await Context.Message.AddReactionAsync(new Emoji(TrtlBotSharp.tipLowBalanceReact));
             }
             else if (TrtlBotSharp.GetBalance(Context.Message.Author.Id) < Convert.ToDecimal(Amount) + TrtlBotSharp.tipFee)
             {
-                await Context.Message.Author.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N}** {1}",
+                await Context.Message.Author.SendMessageAsync(string.Format("Your balance is too low! Amount + Fee = **{0:N2}** {1}",
                     Convert.ToDecimal(Amount) + TrtlBotSharp.tipFee, TrtlBotSharp.coinSymbol));
                 await Context.Message.AddReactionAsync(new Emoji(TrtlBotSharp.tipLowBalanceReact));
             }

--- a/TrtlBotSharp/Utilities.cs
+++ b/TrtlBotSharp/Utilities.cs
@@ -56,7 +56,7 @@ namespace TrtlBotSharp
                 Hashrate /= 1000;
                 i++;
             }
-            return string.Format("{0:N} {1}", Hashrate, Units[i]);
+            return string.Format("{0:N2} {1}", Hashrate, Units[i]);
         }
 
         // Prettifies a message desription

--- a/TrtlBotSharp/Wallet.cs
+++ b/TrtlBotSharp/Wallet.cs
@@ -69,11 +69,11 @@ namespace TrtlBotSharp
                         AddPending(TransactionHash, GetPaymentId(UID), Amount);
 
                         // Set response message
-                        ReplyEmbed.Description = string.Format("You recieved a tip of **{0:N}** {1} from {2}, since you are redirecting tips back to " +
+                        ReplyEmbed.Description = string.Format("You recieved a tip of **{0:N2}** {1} from {2}, since you are redirecting tips back to " +
                             "your tip jar, this will come through as a deposit once confirmed.\nTX: **{3}**", Amount, coinSymbol,
                             _client.GetUser(Sender).Username, TransactionHash);
                     }
-                    else ReplyEmbed.Description = string.Format("You recieved a tip of **{0:N}** {1} from {2}!\nTX: **{3}**", Amount, coinSymbol,
+                    else ReplyEmbed.Description = string.Format("You recieved a tip of **{0:N2}** {1} from {2}!\nTX: **{3}**", Amount, coinSymbol,
                         _client.GetUser(Sender).Username, TransactionHash);
 
                     // Send message
@@ -84,9 +84,9 @@ namespace TrtlBotSharp
                 var Response = new EmbedBuilder();
                 Response.WithTitle("Tip sent!");
                 if (Recipients.Count == 1)
-                    Response.Description = string.Format("You sent a tip of **{0:N}** {1} to 1 user\nNew balance: **{2:N}** {1}\nTX: **{3}**",
+                    Response.Description = string.Format("You sent a tip of **{0:N2}** {1} to 1 user\nNew balance: **{2:N2}** {1}\nTX: **{3}**",
                         Amount, coinSymbol, Balance, TransactionHash);
-                else Response.Description = string.Format("You sent a tip of **{0:N}** {1} to {2} users\nNew balance: **{3:N}** {1}\nTX: **{4}**",
+                else Response.Description = string.Format("You sent a tip of **{0:N2}** {1} to {2} users\nNew balance: **{3:N2}** {1}\nTX: **{4}**",
                         Amount, coinSymbol, Recipients.Count, Balance, TransactionHash);
 
                 // Send message
@@ -138,13 +138,13 @@ namespace TrtlBotSharp
                 if (GetAddress(Sender) == Recipient)
                 {
                     Response.WithTitle("Withdrawal sent!");
-                    Response.Description = string.Format("You withdrew **{0:N}** {1} to {2}\nNew balance: **{3:N}** {1}\nTX: **{4}**",
+                    Response.Description = string.Format("You withdrew **{0:N2}** {1} to {2}\nNew balance: **{3:N2}** {1}\nTX: **{4}**",
                         Amount, coinSymbol, Recipient, Balance, TransactionHash);
                 }
                 else
                 {
                     Response.WithTitle("Tip sent!");
-                    Response.Description = string.Format("You sent a tip of **{0:N}** {1} to {2}\nNew balance: **{3:N}** {1}\nTX: **{4}**",
+                    Response.Description = string.Format("You sent a tip of **{0:N2}** {1} to {2}\nNew balance: **{3:N2}** {1}\nTX: **{4}**",
                         Amount, coinSymbol, Recipient, Balance, TransactionHash);
                 }
 
@@ -206,7 +206,7 @@ namespace TrtlBotSharp
 
             // Get last sync height
             int SyncHeight = GetSyncHeight();
-            Log(0, "Wallet", "Starting sync, {0:N0} blocks behind", ((int)Result["blockCount"] - SyncHeight));
+            Log(0, "Wallet", "Starting sync, {0:N2} blocks behind", ((int)Result["blockCount"] - SyncHeight));
 
             // Loop while connected
             while (Result.Count > 0 && !Result.ContainsKey("error"))
@@ -226,7 +226,7 @@ namespace TrtlBotSharp
                     while (SyncHeight < CurrentHeight)
                     {
                         // Log that syncing has started
-                        Log(1, "Wallet", "Scanning for deposits from height: {0:N0}", SyncHeight);
+                        Log(1, "Wallet", "Scanning for deposits from height: {0:N2}", SyncHeight);
 
                         // Set sync chunk size
                         int SyncSize = 1000;
@@ -340,7 +340,7 @@ namespace TrtlBotSharp
                                 // Begin building a message
                                 var Response = new EmbedBuilder();
                                 Response.WithTitle("Deposit recieved!");
-                                Response.Description = string.Format("Your deposit of **{0:N}** {1} has now been credited.\nNew balance: **{2:N}** {1}\nTX: **{3}**",
+                                Response.Description = string.Format("Your deposit of **{0:N2}** {1} has now been credited.\nNew balance: **{2:N2}** {1}\nTX: **{3}**",
                                     Difference, coinSymbol, Balance, ConfirmedTransaction.Key);
 
                                 // Send message
@@ -383,7 +383,7 @@ namespace TrtlBotSharp
                                 // Begin building a message
                                 var Response = new EmbedBuilder();
                                 Response.WithTitle("Tip processed!");
-                                Response.Description = string.Format("A tip of **{0:N}** {1} that was sent to you has now been credited.\nNew balance: **{2:N}** {1}\nTX: **{3}**",
+                                Response.Description = string.Format("A tip of **{0:N2}** {1} that was sent to you has now been credited.\nNew balance: **{2:N2}** {1}\nTX: **{3}**",
                                     Pending, coinSymbol, Balance + Pending, ConfirmedTransaction.Key);
 
                                 // Send message


### PR DESCRIPTION
I've replaced all {x:N} format specifiers with {x:N2} to be more ignorant of culture.
My machine thinks it should give 3 for some reason, so this was the best fix I could find. 